### PR TITLE
fix: added shebang in the setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -f config.env ]; then
     echo "config.env already exists, skipping"


### PR DESCRIPTION
This commit is trivial. It is to append the shebang in the setup.sh file. 

It is not always the case that /bin/bash is the path to the Bash shell. 
It is only a different path in extremely rare instances, so it is typically irrelevant.
 This commit is to specify the Bash shell (i.e., bash) using the environment variable.

Signed-off-by: Geunsik Lim <leemgs@gmail.com>