### PR TITLE
Fixed the bug that caused downloading of models to be skipped

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -61,9 +61,11 @@ echo "NUM_GPUS=${NUM_GPUS}" >> config.env
 echo "MODEL_DIR=${MODEL_DIR}" >> config.env
 
 if [ -d "$MODEL_DIR"/"${MODEL}"-${NUM_GPUS}gpu ]; then
-    echo "Converted model for ${MODEL}-${NUM_GPUS}gpu already exists, skipping"
-    echo "Please delete ${MODEL_DIR}/${MODEL}-${NUM_GPUS}gpu if you want to re-convert it"
-    exit 0
+    echo "Converted model for ${MODEL}-${NUM_GPUS}gpu already exists."
+    read -p "Do you want to re-use it? y/n: " REUSE_CHOICE
+    if [ "${REUSE_CHOICE^^}" = "Y" ]; then
+        exit 0
+    fi
 fi
 
 # Create model directory

--- a/setup.sh
+++ b/setup.sh
@@ -60,29 +60,28 @@ echo "MODEL=${MODEL}" > config.env
 echo "NUM_GPUS=${NUM_GPUS}" >> config.env
 echo "MODEL_DIR=${MODEL_DIR}" >> config.env
 
-if [ -d "$MODEL_DIR"/"${MODEL}"-"${NUM_GPUS}"gpu ]; then
-    echo "Converted model for ${MODEL}-${NUM_GPUS}gpu already exists."
-    read -p "Do you want to re-use it? y/n: " REUSE_CHOICE
-    if ${REUSE_CHOICE^^} != "Y"; then
-      # Create model directory
-      mkdir -p "${MODEL_DIR}"
-
-      # For some of the models we can download it pre-converted.
-      if [ "$NUM_GPUS" -le 2 ]; then
-          echo "Downloading the model from HuggingFace, this will take a while..."
-          SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
-          DEST="${MODEL}-${NUM_GPUS}gpu"
-          ARCHIVE="${MODEL_DIR}/${DEST}.tar.zst"
-          cp -r "$SCRIPT_DIR"/converter/models/"$DEST" "${MODEL_DIR}"
-          curl -L "https://huggingface.co/moyix/${MODEL}-gptj/resolve/main/${MODEL}-${NUM_GPUS}gpu.tar.zst" \
-              -o "$ARCHIVE"
-          zstd -dc "$ARCHIVE" | tar -xf - -C "${MODEL_DIR}"
-          rm -f "$ARCHIVE"
-      else
-          echo "Downloading and converting the model, this will take a while..."
-          docker run --rm -v "${MODEL_DIR}":/models -e MODEL="${MODEL}" -e NUM_GPUS="${NUM_GPUS}" moyix/model_converter:latest
-      fi
-    fi
+if [ -d "$MODEL_DIR"/"${MODEL}"-${NUM_GPUS}gpu ]; then
+    echo "Converted model for ${MODEL}-${NUM_GPUS}gpu already exists, skipping"
+    echo "Please delete ${MODEL_DIR}/${MODEL}-${NUM_GPUS}gpu if you want to re-convert it"
+    exit 0
 fi
 
+# Create model directory
+mkdir -p "${MODEL_DIR}"
+
+# For some of the models we can download it preconverted.
+if [ $NUM_GPUS -le 2 ]; then
+    echo "Downloading the model from HuggingFace, this will take a while..."
+    SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+    DEST="${MODEL}-${NUM_GPUS}gpu"
+    ARCHIVE="${MODEL_DIR}/${DEST}.tar.zst"
+    cp -r "$SCRIPT_DIR"/converter/models/"$DEST" "${MODEL_DIR}"
+    curl -L "https://huggingface.co/moyix/${MODEL}-gptj/resolve/main/${MODEL}-${NUM_GPUS}gpu.tar.zst" \
+        -o "$ARCHIVE"
+    zstd -dc "$ARCHIVE" | tar -xf - -C "${MODEL_DIR}"
+    rm -f "$ARCHIVE"
+else
+    echo "Downloading and converting the model, this will take a while..."
+    docker run --rm -v ${MODEL_DIR}:/models -e MODEL=${MODEL} -e NUM_GPUS=${NUM_GPUS} moyix/model_converter:latest
+fi
 echo "Done! Now run ./launch.sh to start the FauxPilot server."


### PR DESCRIPTION
This is due to a logical error in 6aa53f2eb3858894444671302520f1b7560374a3.

When `"$MODEL_DIR"/"${MODEL}"-${NUM_GPUS}gpu` does not exist, the model can never be downloaded.