### PR TITLE
fix: fixed incorrect return value in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -3,14 +3,14 @@
 if [ -f config.env ]; then
     echo "config.env already exists, skipping"
     echo "Please delete config.env if you want to re-run this script"
-    exit 0
+    exit 1
 fi
 
 function check_dep(){
     echo "Checking for $1 ..."
     which "$1" 2>/dev/null || {
         echo "Please install $1."
-        exit 0
+        exit 1
     }
 }
 check_dep curl


### PR DESCRIPTION
This commit fixes an incorrect return value in setup.sh. In this bash program.  A score of zero (0) indicates that everything went smoothly. Anything else indicates  a problem. A value of 1 indicates that some type of error has occurred.

Signed-off-by: Geunsik Lim <leemgs@gmail.com>
Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>