### PR TITLE
Two patches for the vim support

### DIFF
--- a/copilot_proxy/app.py
+++ b/copilot_proxy/app.py
@@ -2,7 +2,7 @@ import os
 
 import uvicorn
 from fastapi import FastAPI, Response
-from sse_starlette.sse import EventSourceResponse
+from fastapi.responses import StreamingResponse
 
 from models import OpenAIinput
 from utils.codegen import CodeGenProxy
@@ -28,9 +28,9 @@ async def completions(data: OpenAIinput):
     data = data.dict()
     print(data)
     if data.get("stream") is not None:
-        return EventSourceResponse(
-            content=codegen(data=data),
+        return StreamingResponse(
             status_code=200,
+            content=codegen(data=data),
             media_type="text/event-stream"
         )
     else:

--- a/copilot_proxy/models.py
+++ b/copilot_proxy/models.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 
 
 class OpenAIinput(BaseModel):
-    model: str
+    model: Optional[str] = 'codegen'
     prompt: Optional[str]
     suffix: Optional[str]
     max_tokens: Optional[int] = 16


### PR DESCRIPTION
Mentioned in #72 .

The first one fixed the response for event stream requests used by `getCompletions` in the vim plugin.
Instead of replying `data: {json string}`, it's replying `data: data: {json string}` without the fix.

The second one makes `model` parameter to be optional for copilot proxy.
Or else copilot proxy will raise `field required` error.
Printing the data form from the request shows that there is no data payload.