### PR TITLE
Add basic CI that tests the Python backend

### DIFF
--- a/.github/workflows/python_backend_tests.yaml
+++ b/.github/workflows/python_backend_tests.yaml
@@ -12,9 +12,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r tests/python_backend/requirements.txt
-      - name: Download container
+      - name: Build container
         run: |
-          docker pull moyix/triton_with_ft:22.09
+          docker compose build
       - name: Run tests
         run: pytest tests
 

--- a/.github/workflows/python_backend_tests.yaml
+++ b/.github/workflows/python_backend_tests.yaml
@@ -14,7 +14,9 @@ jobs:
           pip install -r tests/python_backend/requirements.txt
       - name: Build container
         run: |
-          docker compose build
+          cp tests/python_backend/runner.env .env &&
+          docker compose build &&
+          rm -f .env
       - name: Run tests
         run: pytest tests
 

--- a/.github/workflows/python_backend_tests.yaml
+++ b/.github/workflows/python_backend_tests.yaml
@@ -5,13 +5,13 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v3
-        - uses: actions/setup-python@v4
-        - name: Install dependencies
-          run: |
-            python -m pip install --upgrade pip
-            pip install -r tests/python_backend/requirements.txt
-        - name: Run tests
-          run: pytest tests
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r tests/python_backend/requirements.txt
+      - name: Run tests
+        run: pytest tests
 

--- a/.github/workflows/python_backend_tests.yaml
+++ b/.github/workflows/python_backend_tests.yaml
@@ -1,0 +1,17 @@
+name: FauxPilot Python Backend Tests
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v3
+        - uses: actions/setup-python@v4
+        - name: Install dependencies
+          run: |
+            python -m pip install --upgrade pip
+            pip install -r tests/python_backend/requirements.txt
+        - name: Run tests
+          run: pytest tests
+

--- a/.github/workflows/python_backend_tests.yaml
+++ b/.github/workflows/python_backend_tests.yaml
@@ -12,6 +12,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r tests/python_backend/requirements.txt
+      - name: Download container
+        run: |
+          docker pull moyix/triton_with_ft:22.09
       - name: Run tests
         run: pytest tests
 

--- a/tests/python_backend/runner.env
+++ b/tests/python_backend/runner.env
@@ -1,0 +1,8 @@
+NUM_GPUS=1
+GPUS=0
+API_EXTERNAL_PORT=5000
+TRITON_HOST=triton
+TRITON_PORT=8001
+MODEL=py-codegen-350M-mono
+MODEL_DIR=${HOME}/models/py-Salesforce-codegen-350M-mono
+HF_CACHE_DIR=${HOME}/.cache/huggingface

--- a/tests/python_backend/test_setup.py
+++ b/tests/python_backend/test_setup.py
@@ -128,7 +128,7 @@ def test_python_backend(n_gpus: int):
     enter_input(proc, r".*share (your )?huggingface cache[^:]+: ?", "y")
     enter_input(proc, r".*cache directory[^:]+: ?", "")  # default
     enter_input(proc, r".*use int8[^:]+: ?", "n")
-    enter_input(proc, r".*run FauxPilot\? \[y/n\] ", "n")
+    enter_input(proc, r".*run FauxPilot\? \[y/n\] ", "n", timeout=120)
 
     # copy $root/.env to $curdir/test.env
     shutil.copy(str(root/".env"), str(curdir/"test.env"))


### PR DESCRIPTION
This adds an initial Actions workflow that does a basic test of the Python backend. Currently only the Python backend is tested, rather than the default FT backend, because GitHub actions doesn't have GPUs on their runners. Hopefully we can fix this soon with a self-hosted runner...