### PR TITLE
bug: improved if statement to compare float number

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -31,10 +31,15 @@ while getopts "hd" option; do
    esac
 done
 
-# On versions above 20.10.2, docker-compose is docker compose
-smaller=$(printf "$(docker --version | egrep -o '[0-9]+\.[0-9]+\.[0-9]+')\n20.10.2" | sort -V | head -n1)
-if [[ "$smaller" == "20.10.2" ]]; then
-  docker compose up $options --remove-orphans --build
+# On versions above 20.10.2, docker-compose is "docker compose".
+DOCKER_STR=$(docker --version)
+DOCKER_VER=$(echo "$DOCKER_STR" | sed -n 's/.*\([0-9]\{2\}\.[0-9]\{2\}\.[0-9]\{2\}\).*/\1/p')
+
+echo "$DOCKER_VER ge 20.10.2"
+if dpkg --compare-versions $DOCKER_VER gt 20.10.2; then
+  DOCKER_CMD="docker-compose"
 else
-  docker-compose up $options --remove-orphans --build
-fi;
+  DOCKER_CMD="docker compose"
+fi
+$DOCKER_CMD up $options --remove-orphans --build
+

--- a/setup.sh
+++ b/setup.sh
@@ -22,6 +22,7 @@ function check_dep(){
 check_dep curl
 check_dep zstd
 check_dep docker
+check_dep dpkg
 
 ############### Common configuration ###############
 


### PR DESCRIPTION
By default, bash does not support operations that can compare floating numbers.
And you can compare floating numbers using the bc command, but you will encounter
a syntax error due to compatibility issues. So, This commit is to compare
floating numbers using Ubuntu's dpkg command, which is basically adopted by Fauxpilot.
Because we use the dpkg command, comparisons of floating numbers are more efficient
and more compatible with operation.

Resolved https://github.com/fauxpilot/fauxpilot/issues/159.

Signed-off-by: Geunsik Lim <leemgs@gmail.com>
Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>