### PR TITLE
fix: workaround pip version check

### DIFF
--- a/proxy.Dockerfile
+++ b/proxy.Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /python-docker
 
 COPY copilot_proxy/requirements.txt requirements.txt
 
-RUN pip3 install --no-cache-dir -r requirements.txt
+RUN pip3 install --disable-pip-version-check --no-cache-dir -r requirements.txt
 
 COPY copilot_proxy .
 


### PR DESCRIPTION
## 1. General Description
workaround pip version check

## 2. Changes proposed in this PR:

## 3. How to evaluate:
1. Describe how to evaluate such that it may be reproduced by the reviewer (s).
    1. run `./launch.sh`
1. Self assessment:
 - [x] Successfully build locally `docker-compose build`:
 - [x] Successfully tested the full solution locally
