### PR TITLE
Its not actually github copilot, its an alternative.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # FauxPilot
 
-This is an attempt to build a locally hosted version of [GitHub Copilot](https://copilot.github.com/). It uses the [SalesForce CodeGen](https://github.com/salesforce/CodeGen) models inside of NVIDIA's [Triton Inference Server](https://developer.nvidia.com/nvidia-triton-inference-server) with the [FasterTransformer backend](https://github.com/triton-inference-server/fastertransformer_backend/).
+This is an attempt to build a locally hosted alternative to [GitHub Copilot](https://copilot.github.com/). It uses the [SalesForce CodeGen](https://github.com/salesforce/CodeGen) models inside of NVIDIA's [Triton Inference Server](https://developer.nvidia.com/nvidia-triton-inference-server) with the [FasterTransformer backend](https://github.com/triton-inference-server/fastertransformer_backend/).
 
 <p align="right">
   <img width="50%" align="right" src="./img/fauxpilot.png">


### PR DESCRIPTION
At the moment it infers that you will actually have a locally hosted version of CoPilot, which MS/Github may have a problem with - as its not true, and its a product they actually charge for.

This updates readme to say it is an alternative, which is indisputable. Its probably also best to update the repo description.