### PR TITLE
fix stream conditional statement

### DIFF
--- a/copilot_proxy/app.py
+++ b/copilot_proxy/app.py
@@ -62,7 +62,7 @@ async def completions(data: OpenAIinput):
             code=None,
         )
 
-    if data.get("stream") is not None:
+    if data.get("stream", False):
         return EventSourceResponse(
             content=content,
             status_code=200,


### PR DESCRIPTION
---
## 1. General Description
<!-- Describe what this PR intents to do -->
This PR intends to fix the conditional statement on [stream](https://platform.openai.com/docs/api-reference/completions/create#completions/create-stream), which is an OpenAI input used to control whether to return server-sent events (SSE). The `stream` is a boolean value that holds true or false.

The original logic only checks whether the OpenAI input contains the key `stream`. Sometimes people may explicitly send `stream=False` as one of the parameters of OpenAI Create Completion API, and in this case, only checking whether the key exists will make the request be regarded as streaming.


## 2. Changes proposed in this PR:
<!-- Bulleted lists are also acceptable. Typically, a hyphen or asterisk before the bullet, followed by a single space.-->
1. Since the OpenAI parameter [stream](https://platform.openai.com/docs/api-reference/completions/create#completions/create-stream) has a default value as False. Change `if data.get("stream") is not None:` to `if data.get("stream", False):` can address the issue when the OpenAI input contains `{"stream": False}`.


## 3. How to evaluate:
1. Describe how to evaluate such that it may be reproduced by the reviewer (s).
1. Self assessment:
 - [x] Successfully build locally `docker-compose build`:
 - [x] Successfully tested the full solution locally
