### PR TITLE
Add support codegen2

### DIFF
--- a/converter/codegen_gptj_convert.py
+++ b/converter/codegen_gptj_convert.py
@@ -19,7 +19,7 @@ parser.add_argument('output_dir', help='where to store the converted model')
 args = parser.parse_args()
 
 print('Loading CodeGen model')
-cg_model = CodeGenForCausalLM.from_pretrained(args.code_model, torch_dtype="auto", trust_remote_code=True)
+cg_model = CodeGenForCausalLM.from_pretrained(args.code_model, torch_dtype="auto", trust_remote_code=bool("codegen2" in args.code_model))
 cg_config = cg_model.config
 
 # Create empty GPTJ model

--- a/converter/codegen_gptj_convert.py
+++ b/converter/codegen_gptj_convert.py
@@ -76,7 +76,9 @@ with torch.no_grad():
             # GPT-J and CodeGen slice up the qkv projection slightly differently.
             # After a great deal of pain, I figured out that this permutation on
             # the weights of the qkv_proj fixes it.
-            base_permutation = [0, 3, 6, 9, 1, 4, 7, 10, 2, 5, 8, 11]
+            base_permutation = [0, 3, 6, 9,
+                                1, 4, 7, 10, 
+                                2, 5, 8, 11]
             if args.code_model in ["Salesforce/codegen2-1B", "Salesforce/codegen2-3_7B"]:
                 # codegen2-1B and codegen2-3_7B were trained on different mp setting
                 # see: https://github.com/fauxpilot/fauxpilot/issues/202

--- a/converter/codegen_gptj_convert.py
+++ b/converter/codegen_gptj_convert.py
@@ -7,16 +7,19 @@ from transformers import GPTJForCausalLM, GPTJConfig
 from transformers import CodeGenTokenizer, CodeGenForCausalLM  # noqa: F401
 from transformers import CODEGEN_PRETRAINED_MODEL_ARCHIVE_LIST
 
+convertable_models = CODEGEN_PRETRAINED_MODEL_ARCHIVE_LIST + [
+    "Salesforce/codegen2-1B", "Salesforce/codegen2-3_7B", "Salesforce/codegen2-7B", "Salesforce/codegen2-16B"]
+
 parser = argparse.ArgumentParser('Convert SalesForce CodeGen model to GPT-J')
 parser.add_argument('--code_model',
-                    choices=CODEGEN_PRETRAINED_MODEL_ARCHIVE_LIST, default='Salesforce/codegen-350M-multi',
+                    choices=convertable_models, default='Salesforce/codegen-350M-multi',
                     help='which SalesForce model to convert'
                     )
 parser.add_argument('output_dir', help='where to store the converted model')
 args = parser.parse_args()
 
 print('Loading CodeGen model')
-cg_model = CodeGenForCausalLM.from_pretrained(args.code_model, torch_dtype="auto")
+cg_model = CodeGenForCausalLM.from_pretrained(args.code_model, torch_dtype="auto", trust_remote_code=True)
 cg_config = cg_model.config
 
 # Create empty GPTJ model
@@ -70,11 +73,18 @@ with torch.no_grad():
         if 'qkv_proj' in name:
             qkv_proj = param.detach().clone()
             mp_num = 4  # number of cores on their TPU I guess?
-            local_dim = embed_dim // mp_num
             # GPT-J and CodeGen slice up the qkv projection slightly differently.
             # After a great deal of pain, I figured out that this permutation on
             # the weights of the qkv_proj fixes it.
             base_permutation = [0, 3, 6, 9, 1, 4, 7, 10, 2, 5, 8, 11]
+            if args.code_model in ["Salesforce/codegen2-1B", "Salesforce/codegen2-3_7B"]:
+                # codegen2-1B and codegen2-3_7B were trained on different mp setting
+                # see: https://github.com/fauxpilot/fauxpilot/issues/202
+                base_permutation = [0, 3, 6, 9, 12, 15, 18, 21,
+                                    1, 4, 7, 10, 13, 16, 19, 22,
+                                    2, 5, 8, 11, 14, 17, 20, 23]
+                mp_num = 8
+            local_dim = embed_dim // mp_num
             permutation = torch.cat([torch.arange(i * local_dim, (i + 1) * local_dim) for i in base_permutation])
             # NB: we permute the *rows* here because the computation is xA.T
             new_qkv_proj = qkv_proj[permutation, :]


### PR DESCRIPTION
---
## 1. General Description
This PR adds support to convert models from Codegen-2 to GPT-J.
It does not modify the functionality of the existing converter. The PR seems quite small, but took me hours of debugging to figure out that the architecture of codegen2 is actually fully compatible for the large (7, 16B versions).
For the smaller models, a different permutation order is required, because the smaller models (1, 3_7B versions)were trained on another TPU setting.


## 2. Changes proposed in this PR:
<!-- Bulleted lists are also acceptable. Typically, a hyphen or asterisk before the bullet, followed by a single space.-->
1. https://github.com/fauxpilot/fauxpilot/issues/202

Resolves: #202 

## 3. How to evaluate:
1. Describe how to evaluate such that it may be reproduced by the reviewer (s).
    1.

1. Self assessment:
 - [ ] Successfully build locally `docker-compose build`:
 - [ ] Successfully tested the full solution locally
 - [x] Integrated this PR from here: https://github.com/OpenNMT/CTranslate2/pull/1230 and ran the conversion once. Don't have enough capacity to fully end-to-end test the whole solution for this framework.