### PR TITLE
Update `use_half` in config_template.pbtxt to horner the args from init_model.py

### DIFF
--- a/python_backend/config_template.pbtxt
+++ b/python_backend/config_template.pbtxt
@@ -151,7 +151,7 @@ instance_group [
 parameters {
   key: "use_half"
   value: {
-    string_value: "1"
+    string_value: "${use_half}" # e.g. "0" or "1"
   }
 }
 parameters {


### PR DESCRIPTION
---
## 1. General Description
<!-- Describe what this PR intents to do -->

Update `use_half` in config_template.pbtxt to horner the args from init_model.py


## 2. Changes proposed in this PR:
<!-- Bulleted lists are also acceptable. Typically, a hyphen or asterisk before the bullet, followed by a single space.-->
1. `use_half` now can be updated by calling init_model.py --use-half "1"/"0"
1.

Resolves: #{GitHub-Issue-Number}
See also: #{GitHub-Issue-Number}


## 3. How to evaluate:
1. Describe how to evaluate such that it may be reproduced by the reviewer (s).
    1. python init_model.py --use-half "1" -> check config.pbtxt, the value becomes "1"
    1. python init_model.py --use-half "0" -> check config.pbtxt, the value becomes "0"
    1.
1. Self assessment:
 - [x] Successfully build locally `docker-compose build`:
 - [x] Successfully tested the full solution locally
