### PR TITLE
Use os.path.join to get the model name in case the org_name is empty

### DIFF
--- a/python_backend/model.py
+++ b/python_backend/model.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 import torch
 import triton_python_backend_utils as pb_utils
@@ -25,7 +26,7 @@ class TritonPythonModel:
     def initialize(self, args):
         self.model_config = model_config = json.loads(args["model_config"])
         org_name = model_config["parameters"].get("org_name", {"string_value": "Salesforce"})["string_value"]
-        model_name = org_name + "/" + model_config["parameters"]["model_name"]["string_value"]
+        model_name = os.path.join(org_name, model_config["parameters"]["model_name"]["string_value"])
 
         def get_bool(x):
             return model_config["parameters"][x]["string_value"].lower() in ["1", "true"]


### PR DESCRIPTION
---
## 1. General Description
<!-- Describe what this PR intents to do -->
Use `os.path.join` to get the model name in case the org_name is empty


## 2. Changes proposed in this PR:
<!-- Bulleted lists are also acceptable. Typically, a hyphen or asterisk before the bullet, followed by a single space.-->
1.
1.

Resolves: #{GitHub-Issue-Number}
See also: #{GitHub-Issue-Number}


## 3. How to evaluate:
1. Describe how to evaluate such that it may be reproduced by the reviewer (s).
    1. Add a new model in setup.py (MODEL="gpt2"; ORG="")
    1. gpt2 model can be downloaded from HF and run
    1.
1. Self assessment:
 - [x] Successfully build locally `docker-compose build`:
 - [x] Successfully tested the full solution locally
